### PR TITLE
Specify the default tenant during user create

### DIFF
--- a/libraries/openstack_user.rb
+++ b/libraries/openstack_user.rb
@@ -31,12 +31,14 @@ module OpenstackclientCookbook
 
     action :create do
       user = connection.users.find { |u| u.name == user_name }
+      project = connection.projects.find { |p| p.name == project_name }
       if user
         log "User with name: \"#{user_name}\" already exists"
       else
         connection.users.create(
           name: user_name,
           email: email,
+          default_project_id: project ? project.id : nil,
           password: password
         )
       end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -65,6 +65,7 @@ describe 'openstackclient_test::user' do
 
   let(:found_project) do
     double :find,
+           id: 42,
            grant_role_to_user: true,
            revoke_role_from_user: true
   end
@@ -133,6 +134,7 @@ describe 'openstackclient_test::user' do
         .with(
           name: 'myuser',
           email: 'myemail',
+          default_project_id: 42,
           password: 'mypassword'
         )
       chef_run


### PR DESCRIPTION
If the project tenant is given when creating the user account,
honor it by assigning that as the _default_ project tenant.

This is especially helpful when creating initial service accounts and
assigning them to the `service` project).