### PR TITLE
Grant domain

### DIFF
--- a/libraries/openstack_user.rb
+++ b/libraries/openstack_user.rb
@@ -85,16 +85,14 @@ module OpenstackclientCookbook
       user = connection.users.find { |u| u.name == user_name }
       domain = connection.domains.find { |p| p.name == domain_name }
       role = connection.roles.find { |r| r.name == role_name }
-      connection.grant_domain_user_role(
-        domain.id, user.id, role.id) if role && domain && user
+      user.grant_role role.id if role && domain && user
     end
 
     action :revoke_domain do
       user = connection.users.find { |u| u.name == user_name }
       domain = connection.domains.find { |p| p.name == domain_name }
       role = connection.roles.find { |r| r.name == role_name }
-      connection.revoke_domain_user_role(
-        domain.id, user.id, role.id) if role && domain && user
+      user.revoke_role  role.id if role && domain && user
     end
   end
 end

--- a/libraries/openstack_user.rb
+++ b/libraries/openstack_user.rb
@@ -32,8 +32,17 @@ module OpenstackclientCookbook
     action :create do
       user = connection.users.find { |u| u.name == user_name }
       project = connection.projects.find { |p| p.name == project_name }
+      domain = connection.domains.find { |u| u.name == domain_name }
       if user
         log "User with name: \"#{user_name}\" already exists"
+      elsif domain
+        connection.users.create(
+          name: user_name,
+          domain_id: domain.id,
+          email: email,
+          default_project_id: project ? project.id : nil,
+          password: password
+        )
       else
         connection.users.create(
           name: user_name,

--- a/libraries/openstack_user.rb
+++ b/libraries/openstack_user.rb
@@ -62,6 +62,7 @@ module OpenstackclientCookbook
       end
     end
 
+    # Grant a role in a project
     action :grant_role do
       user = connection.users.find { |u| u.name == user_name }
       project = connection.projects.find { |p| p.name == project_name }
@@ -76,6 +77,10 @@ module OpenstackclientCookbook
       project.revoke_role_from_user role.id, user.id if role && project && user
     end
 
+    # Grant a role in a domain
+    # Note: in spite of what the action name may suggest, the domain name is
+    # only used to identify a user who is in that domain. This action grants
+    # the user a role in the domain.
     action :grant_domain do
       user = connection.users.find { |u| u.name == user_name }
       domain = connection.domains.find { |p| p.name == domain_name }

--- a/spec/cookbooks/openstackclient_test/recipes/user.rb
+++ b/spec/cookbooks/openstackclient_test/recipes/user.rb
@@ -49,7 +49,6 @@ end
 
 openstack_user 'myuser' do
   role_name 'myrole'
-  project_name 'myproject'
   domain_name 'mydomain'
   connection_params connection_params
   action :grant_domain
@@ -57,7 +56,6 @@ end
 
 openstack_user 'myuser' do
   role_name 'myrole'
-  project_name 'myproject'
   domain_name 'mydomain'
   connection_params connection_params
   action :revoke_domain

--- a/spec/domain_spec.rb
+++ b/spec/domain_spec.rb
@@ -19,7 +19,9 @@ require_relative '../libraries/openstack_domain'
 
 describe 'openstackclient_test::domain' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(step_into: ['openstack_domain'])
+    runner = ChefSpec::SoloRunner.new(
+      UBUNTU_OPTS.merge(step_into: ['openstack_domain'])
+    )
     runner.converge(described_recipe)
   end
 

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -19,7 +19,9 @@ require_relative '../libraries/openstack_endpoint'
 
 describe 'openstackclient_test::endpoint' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(step_into: ['openstack_endpoint'])
+    runner = ChefSpec::SoloRunner.new(
+      UBUNTU_OPTS.merge(step_into: ['openstack_endpoint'])
+    )
     runner.converge(described_recipe)
   end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -19,7 +19,9 @@ require_relative '../libraries/openstack_project'
 
 describe 'openstackclient_test::project' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(step_into: ['openstack_project'])
+    runner = ChefSpec::SoloRunner.new(
+      UBUNTU_OPTS.merge(step_into: ['openstack_project'])
+    )
     runner.converge(described_recipe)
   end
 

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -19,7 +19,9 @@ require_relative '../libraries/openstack_role'
 
 describe 'openstackclient_test::role' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(step_into: ['openstack_role'])
+    runner = ChefSpec::SoloRunner.new(
+      UBUNTU_OPTS.merge(step_into: ['openstack_role'])
+    )
     runner.converge(described_recipe)
   end
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -19,7 +19,9 @@ require_relative '../libraries/openstack_service'
 
 describe 'openstackclient_test::service' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(step_into: ['openstack_service'])
+    runner = ChefSpec::SoloRunner.new(
+      UBUNTU_OPTS.merge(step_into: ['openstack_service'])
+    )
     runner.converge(described_recipe)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,4 +23,9 @@ RSpec.configure do |config|
   config.log_level = :error
 end
 
+UBUNTU_OPTS = {
+  platform: 'ubuntu',
+  version: '16.04'
+}.freeze
+
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -133,6 +133,7 @@ describe 'openstackclient_test::user' do
       expect(users_empty).to receive(:create)
         .with(
           name: 'myuser',
+          domain_id: 5,
           email: 'myemail',
           default_project_id: 42,
           password: 'mypassword'

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -19,7 +19,9 @@ require_relative '../libraries/openstack_user'
 
 describe 'openstackclient_test::user' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(step_into: ['openstack_user'])
+    runner = ChefSpec::SoloRunner.new(
+      UBUNTU_OPTS.merge(step_into: ['openstack_user'])
+    )
     runner.converge(described_recipe)
   end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -35,7 +35,9 @@ describe 'openstackclient_test::user' do
   let(:found_user) do
     double :find,
            id: 4,
-           destroy: true
+           destroy: true,
+           grant_role: true,
+           revoke_role: true
   end
 
   let(:users_populated) do
@@ -155,9 +157,7 @@ describe 'openstackclient_test::user' do
              users: users_populated,
              domains: domains_populated,
              roles: roles_populated,
-             projects: projects_populated,
-             grant_domain_user_role: true,
-             revoke_domain_user_role: true
+             projects: projects_populated
     end
 
     before do
@@ -244,14 +244,14 @@ describe 'openstackclient_test::user' do
     end
 
     it do
-      expect(connection_dub).to receive(:grant_domain_user_role)
-        .with(5, 4, 3)
+      expect(found_user).to receive(:grant_role)
+        .with(3)
       chef_run
     end
 
     it do
-      expect(connection_dub).to receive(:revoke_domain_user_role)
-        .with(5, 4, 3)
+      expect(found_user).to receive(:revoke_role)
+        .with(3)
       chef_run
     end
   end


### PR DESCRIPTION
These changes should fix some confusion over the use of domain roles in OpenStack. The new domain name attribute will be used in a changed Orchestration/Heat cookbook.