### PR TITLE
Allow user creation in domain other than default

### DIFF
--- a/libraries/openstack_user.rb
+++ b/libraries/openstack_user.rb
@@ -32,8 +32,17 @@ module OpenstackclientCookbook
     action :create do
       user = connection.users.find { |u| u.name == user_name }
       project = connection.projects.find { |p| p.name == project_name }
+      domain = connection.domains.find { |u| u.name == domain_name }
       if user
         log "User with name: \"#{user_name}\" already exists"
+      elsif domain
+        connection.users.create(
+          name: user_name,
+          domain_id: domain.id,
+          email: email,
+          default_project_id: project ? project.id : nil,
+          password: password
+        )
       else
         connection.users.create(
           name: user_name,

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,6 +21,6 @@ license 'Apache v2.0'
 description 'Installs the fog-openstack gem and offers LWRPs to use it'
 issues_url 'https://github.com/cloudbau/cookbook-openstackclient/issues'
 source_url 'https://github.com/cloudbau/cookbook-openstackclient'
-version '0.1.1'
+version '15.0.1'
 
 gem 'fog-openstack'

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -133,6 +133,7 @@ describe 'openstackclient_test::user' do
       expect(users_empty).to receive(:create)
         .with(
           name: 'myuser',
+          domain_id: 5,
           email: 'myemail',
           default_project_id: 42,
           password: 'mypassword'


### PR DESCRIPTION
For reasonably recent OpenStack releases, users are always created in a
domain (by default in the aptly named 'Default' domain). With this
patch, a new domain name attribute can be passed to the openstack_user's
:create action in order to create a user in a specific domain.